### PR TITLE
Replace quote deletion with quote hiding

### DIFF
--- a/eventset.php
+++ b/eventset.php
@@ -1,0 +1,38 @@
+<?php
+	require_once("sitewide/opener.php");
+?>
+	<title>TPE Event Settings</title>
+<?php
+	
+	if (!isset($_SESSION['loggedIn'])) {
+  		$_SESSION['loggedIn'] = FALSE;
+
+  		$_SESSION['redirect'] = "accountset.php"; 
+  		header('Location: login.php');
+	} 
+	else if ($_SESSION['loggedIn'] == FALSE) {
+		$_SESSION['redirect'] = "accountset.php"; 
+		header('Location: login.php');
+	}
+	else {
+		if ($_SESSION['userpermission'] != "admin") {
+			header('Location: members.php');
+		}
+		require_once("sitewide/header.php"); 
+	    require_once("sitewide/membersnav.php");
+	}
+
+?>
+
+<div class="membersPageTitle"> 
+	<span class="orangeTitle">Events</span>
+	<h2 class="memPageDesc">Edit events on the TPE info site</h2>
+</div>
+
+
+
+</div>
+<script src="assets/js/scripts.js"></script>
+<?php 
+    // require_once("sitewide/footer.php");
+?>

--- a/index.php
+++ b/index.php
@@ -45,7 +45,6 @@
 	<?php
 		$positions = array("President", "Vice President", "Treasurer", "Secretary", "Public Relations", "Faculty Advisor");
 
-
 		for ($i=0; $i<count($positions); $i++) { 
 			$eboardQuery = "SELECT Eboard.Position, Eboard.bio, Profiles.propic, Profiles.firstname, Profiles.lastname, Profiles.email
 							FROM Eboard 

--- a/login.php
+++ b/login.php
@@ -105,7 +105,7 @@ if (!empty($_POST)) {
 </div>
 
 
-<a id="githubLink" href="https://github.com/msweet168/rittpe">Website on <img src="media/icons/GithubLogo.png" alt="github" style="width: 15px;"> Github</a>
+<a id="githubLink" href="https://github.com/msweet168/rittpe">Website on Github <img src="media/icons/GithubLogo.png" alt="github" style="width: 15px;"></a>
 
 
 <script src="scripts.js"></script>

--- a/quotes.php
+++ b/quotes.php
@@ -7,8 +7,9 @@
 	$quoteSuccess = "";
 	if (!empty($_POST)) {
 
-		if(isset($_POST["delete"])) {
-			$query = "DELETE FROM Quotes WHERE quoteid = '".$_POST["delete"]."'";
+		if(isset($_POST["hide"])) {
+			$query = "UPDATE Quotes SET hidden = true where quoteid = '".$_POST["hide"]."'";
+			//$query = "DELETE FROM Quotes WHERE quoteid = '".$_POST["hide"]."'";
 			mysqli_query($mysqli, $query);
 		}
 		else if($_POST["quote"]!="" && $_POST["quotee"]!=""){
@@ -66,10 +67,11 @@
 </div>
 
 <?php
-	// if($_SESSION['userpermission'] == "guest") {
-	// 	echo "<h2 style=\"text-align: center;\">Unfortunately, guests cannot view quotes. Please contact an Eboard member to be upgraded to a member account.</h2>";
-	//   	exit();
-	//  }
+	if($_SESSION['userpermission'] == "guest") {
+		echo "<h2 style=\"text-align: center;\">Unfortunately, guests cannot view quotes. </br> Please contact an Eboard member to upgrade your account.</h2>";
+		echo "<script src=\"assets/js/scripts.js\"></script>";
+	  	exit();
+	 }
 ?>
 
 <form id="quoteForm" method="post" onsubmit="return quoteValidate()">
@@ -90,6 +92,9 @@
 
   if ($result && $num_rows > 0) {
     while ($row = mysqli_fetch_assoc($result)) {
+    	if ($row["hidden"] == true) {
+    		continue;
+    	}
 		echo "
 			<div class=\"quoteDiv\">
 				<div class=\"quoteHeader\">
@@ -104,7 +109,7 @@
 		if($_SESSION['userpermission'] == "admin") {
 			echo "
 				<form method=\"post\">
-					<button name=\"delete\" type=\"submit\" value=\"".$row["quoteid"]."\" class=\"quoteDelete\"/>Delete</button>
+					<button name=\"hide\" type=\"submit\" value=\"".$row["quoteid"]."\" class=\"quoteDelete\"/>Delete</button>
 				</form>
 			";
 

--- a/quotes.php
+++ b/quotes.php
@@ -9,7 +9,6 @@
 
 		if(isset($_POST["hide"])) {
 			$query = "UPDATE Quotes SET hidden = true where quoteid = '".$_POST["hide"]."'";
-			//$query = "DELETE FROM Quotes WHERE quoteid = '".$_POST["hide"]."'";
 			mysqli_query($mysqli, $query);
 		}
 		else if($_POST["quote"]!="" && $_POST["quotee"]!=""){
@@ -36,10 +35,6 @@
     		echo"<p>Database error. Please try again...</p>";
     	}
 	}
-
-
-
-
 	
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
@@ -57,9 +52,7 @@
   		// echo "Hello ".$_SESSION["userfirstname"]."! Everything is good, let's read some quotes!<br>";
 	}
 
-
 ?>
-
 
 <div class="membersPageTitle"> 
 	<span class="orangeTitle">Quotevault</span>
@@ -119,9 +112,6 @@
   }
 
 ?>
-
-
-
 
 </div>
 <script src="assets/js/scripts.js"></script>


### PR DESCRIPTION
*Changes to both public and member sites*

### Details 
## Members 
Previously when a site admin would delete a quote from Quotevault, it would also be dropped from the database. This PR changes this flow on the backend by preserving the "deleted" quote in the database but hiding it from the website. This way, quotes can be recovered by having a database admin update the quote's row in the database. This PR makes no changes visible to site users or admins.

In addition, there is a small change to the GitHub link copy on login page. 

### This PR requires a database update 
*Completed on 12/23/18* 

## Public Site 
Adds empty event settings page for site admins to prevent 404 error when navigating to page. 
