### PR TITLE
 Fix typo, exiting -> exciting.

### DIFF
--- a/exhibits.php
+++ b/exhibits.php
@@ -61,7 +61,7 @@
 	createExhibitGallery($makerFairePhotos);
 ?>
 
-<h2 class="textCentered exhibitsFooter">TPE exhibits are even more exiting when experienced in person. Check out our upcoming events!</h1>
+<h2 class="textCentered exhibitsFooter">TPE exhibits are even more exciting when experienced in person. Check out our upcoming events!</h1>
 
 <button onclick="window.location.href='events'" type="button" class="detailButton centered" style="margin-left: auto;">Future Events</button>
 


### PR DESCRIPTION
This PR deploys a simple hotfix to correct a typo on the public exhibits page. 