### PR TITLE
Alphabetize profiles

### DIFF
--- a/members.php
+++ b/members.php
@@ -165,7 +165,7 @@
 
 
 <?php
-	$query = "SELECT firstname, lastname, status, username, email, coastercount, propic FROM Profiles";
+	$query = "SELECT firstname, lastname, status, username, email, coastercount, propic FROM Profiles ORDER BY firstname ASC";
 	$result = mysqli_query($mysqli, $query); 
   	$num_rows = mysqli_affected_rows($mysqli);
 


### PR DESCRIPTION
*Changes to members site only* 

### Details 
Previously, the member panels on the profiles page were ordered by the account creation date. This could be confusing for users trying to find a certain member. This PR updates the query for getting all profiles so the profiles are ordered by first name alphabetically.

No database update is required for this PR to function properly. 