### PR TITLE
 Remove php extension from page links

### DIFF
--- a/accountset.php
+++ b/accountset.php
@@ -7,16 +7,16 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "accountset.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "accountset"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "accountset.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "accountset"; 
+		header('Location: login');
 	}
 	else {
 		if ($_SESSION['userpermission'] != "admin") {
-			header('Location: members.php');
+			header('Location: members');
 		}
 		require_once("sitewide/header.php"); 
 	    require_once("sitewide/membersnav.php");

--- a/chat.php
+++ b/chat.php
@@ -7,12 +7,12 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "chat.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "chat"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "chat.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "chat"; 
+		header('Location: login');
 	}
 	else {
 		require_once("sitewide/header.php"); 

--- a/eboardset.php
+++ b/eboardset.php
@@ -7,16 +7,16 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "accountset.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "eboardset"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "accountset.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "eboardset"; 
+		header('Location: login');
 	}
 	else {
 		if ($_SESSION['userpermission'] != "admin") {
-			header('Location: members.php');
+			header('Location: members');
 		}
 		require_once("sitewide/header.php"); 
 	    require_once("sitewide/membersnav.php");

--- a/eventset.php
+++ b/eventset.php
@@ -7,16 +7,16 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "accountset.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "eventset"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "accountset.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "eventset"; 
+		header('Location: login');
 	}
 	else {
 		if ($_SESSION['userpermission'] != "admin") {
-			header('Location: members.php');
+			header('Location: members');
 		}
 		require_once("sitewide/header.php"); 
 	    require_once("sitewide/membersnav.php");

--- a/index.php
+++ b/index.php
@@ -31,12 +31,12 @@
 <h1 class="contentHeading">Who We Are:</h1>
 <p class="contentDesc"><?= $intro ?></p>
 
-<button onclick="window.location.href='index.php#eboard'" type="button" class="detailButton">Our E-Board</button>
+<button onclick="window.location.href='index#eboard'" type="button" class="detailButton">Our E-Board</button>
 
 <h1 class="contentHeading">What We Do:</h1>
 <p class="contentDesc"><?= $activities?></p>
 
-<button onclick="window.location.href='exhibits.php'" type="button" class="detailButton">Past Exhibits</button>
+<button onclick="window.location.href='exhibits'" type="button" class="detailButton">Past Exhibits</button>
 
 <h1 class="contentHeading">Our E-Board:</h1>
 <a name='eboard'>

--- a/infoset.php
+++ b/infoset.php
@@ -15,16 +15,16 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "accountset.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "infoset"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "accountset.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "infoset"; 
+		header('Location: login');
 	}
 	else {
 		if ($_SESSION['userpermission'] != "admin") {
-			header('Location: members.php');
+			header('Location: members');
 		}
 		require_once("sitewide/header.php"); 
 	    require_once("sitewide/membersnav.php");

--- a/login.php
+++ b/login.php
@@ -7,7 +7,7 @@
 $loginFailed = false; 
 
 if ($_SESSION['loggedIn'] == true) {
-	header('Location: members.php');
+	header('Location: members');
 }
 
 if (!isset($_SESSION['loginRetries'])) {
@@ -56,7 +56,7 @@ if (!empty($_POST)) {
 	        mysqli_query($mysqli, "UPDATE Profiles SET lastlogin = \"".$timestamp."\" WHERE id = \"".$_SESSION['userid']."\"");
 
 	        if (!isset($_SESSION['redirect'])) {
-		  		$_SESSION['redirect'] = "members.php"; 
+		  		$_SESSION['redirect'] = "members"; 
 			} 
 
 	        header('Location: '.$_SESSION['redirect'].'');
@@ -68,7 +68,7 @@ if (!empty($_POST)) {
 	    	 	echo '<script>;
 				      alert("Please contact an Eboard member if you do not know your username or password.");
 				      </script>';
-	    	 	// header('Location: index.php');
+	    	 	//header('Location: index');
 	    	}	
 	    }
 
@@ -84,7 +84,7 @@ if (!empty($_POST)) {
 
 <div class="membersHeader"> 
 	<h1 class="membersTitle">TPE Members</h1>
-	<button type="button" onclick="window.location.href='index.php'" class="infoSiteButton">Exit Members</button>
+	<button type="button" onclick="window.location.href='.'" class="infoSiteButton">Exit Members</button>
 </div>
 
 

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,5 @@
 <?php
 	session_start();
 	session_unset();
-	header('Location: index.php');
+	header('Location: .');
 ?>

--- a/members.php
+++ b/members.php
@@ -47,7 +47,7 @@
 			    $query = "UPDATE Profiles SET password = '".$newPass."' WHERE id = '".$_SESSION['userid']."'";
 			    $result = mysqli_query($mysqli, $query); 
 				if ($result > 0) {
-					header('Location: logout.php');
+					header('Location: logout');
 				}
 			}
 		}
@@ -58,12 +58,12 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "members.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "members"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "members.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "members"; 
+		header('Location: login');
 	}
 	else {
 		require_once("sitewide/header.php"); 

--- a/newsfeed.php
+++ b/newsfeed.php
@@ -7,12 +7,12 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "newsfeed.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "newsfeed"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "newsfeed.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "newsfeed"; 
+		header('Location: login');
 	}
 	else {
 		require_once("sitewide/header.php"); 

--- a/quotes.php
+++ b/quotes.php
@@ -39,12 +39,12 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "quotes.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "quotes"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "quotes.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "quotes"; 
+		header('Location: login');
 	}
 	else {
 		require_once("sitewide/header.php"); 

--- a/sitewide/footer.php
+++ b/sitewide/footer.php
@@ -3,11 +3,11 @@
 
 <div class="footer">
 	<h1 class="footerTitle">RIT Theme Park Enthusiasts</h1>
-	<a href="index.php" class="footerLink">About</a> |
-	<a href="feed.php" class="footerLink">Feed</a> |
-	<a href="exhibits.php" class="footerLink">Exhibits</a> |
-	<a href="events.php" class="footerLink">Events</a> |
-	<a href="members.php" class="footerLink">Members</a>
+	<a href="." class="footerLink">About</a> |
+	<a href="feed" class="footerLink">Feed</a> |
+	<a href="exhibits" class="footerLink">Exhibits</a> |
+	<a href="events" class="footerLink">Events</a> |
+	<a href="members" class="footerLink">Members</a>
 	<p class="footerEnd">Copyright © 2018 RIT Theme Park Enthusiasts</p>
 
 <!-- 	<div>Icons made by <a href="https://www.flaticon.com/authors/smashicons" title="Smashicons">Smashicons</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div> -->

--- a/sitewide/nav.php
+++ b/sitewide/nav.php
@@ -17,7 +17,7 @@
         </li>
 
         <li class = "hide">
-            <a class="<?= thisPage("index") ?>" href="index">About</a>
+            <a class="<?= thisPage("index") ?>" href=".">About</a>
         </li>
 
         <a href="index">
@@ -41,7 +41,7 @@
             </li>
         </a> 
 
-        <li class="hide"><a href="index">About</a></li>
+        <li class="hide"><a href=".">About</a></li>
         <li class="hide"><a href="feed">Feed</a></li>
         <li class="hide"><a href="exhibits">Exhibits</a></li>
         <li class="hide"><a href="events">Events</a></li>

--- a/trips.php
+++ b/trips.php
@@ -7,12 +7,12 @@
 	if (!isset($_SESSION['loggedIn'])) {
   		$_SESSION['loggedIn'] = FALSE;
 
-  		$_SESSION['redirect'] = "trips.php"; 
-  		header('Location: login.php');
+  		$_SESSION['redirect'] = "trips"; 
+  		header('Location: login');
 	} 
 	else if ($_SESSION['loggedIn'] == FALSE) {
-		$_SESSION['redirect'] = "trips.php"; 
-		header('Location: login.php');
+		$_SESSION['redirect'] = "trips"; 
+		header('Location: login');
 	}
 	else {
 		require_once("sitewide/header.php"); 


### PR DESCRIPTION
*Changes to both public and members site* 

### Details
Previously, some pages (including `login.php`) would link to other pages using the `.php` extension. This had the undesired result of showing `.php` in the address bar. This PR address this problem by removing the `.php` extension from wherever it is not needed. 

No database update is required for this PR to function properly. 