### PR TITLE
Fix guest editing issue

### DIFF
--- a/members.php
+++ b/members.php
@@ -6,6 +6,11 @@
 
 	if (!empty($_POST)) {
 
+		if ($_SESSION["userpermission"] == "guest") {
+			header('Location: ./');
+			exit();
+		}
+
 		if ($_POST["email"] != $_SESSION['useremail'] && $_POST["email"] != "") {
 			if (strpos($_POST["email"], '@') && strpos($_POST["email"], '.')) {
 				$newEmail = htmlentities(strip_tags(trim($_POST["email"])));


### PR DESCRIPTION
*Changes to members site only*

### Details
Users logged into the member's site as guests should not be able to edit account information. Previously, a user logged in as a guest would be able to open the javascript console and call a function to pull up the account editor. This would then allow them to edit the account information. 

This PR fixes this problem by putting a validation check in the PHP post handler which checks the user's permissions. If the user is a guest, the update query will not be run. 

A database is not required for this PR to function properly. 